### PR TITLE
auror_hostnames: AXFR and HTTPS added as sources

### DIFF
--- a/server/sner/plugin/auror_hostnames/axfr.py
+++ b/server/sner/plugin/auror_hostnames/axfr.py
@@ -1,0 +1,115 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""axfr related functions for auror_hostnames plugin"""
+
+import logging
+import socket
+
+import dns.name
+import dns.query
+import dns.rcode
+import dns.rdatatype
+import dns.tsigkeyring
+import dns.zone
+
+logger = logging.getLogger(__name__)
+
+
+def query_zone(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    nameserver, zone_str, tsig_key_name=None, tsig_secret=None, tsig_algorithm=None, attempts=10, port=53
+) -> dns.zone.Zone | None:
+    """
+    Queries the dns server for zone transfer, with optional TSIG authentication.
+    Nameserver may be a hostname or an IP address.
+    """
+    try:
+        nameserver_ip = socket.getaddrinfo(nameserver, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM)[0][4][0]
+    except socket.gaierror:
+        logger.error("Unable to resolve nameserver %s", nameserver)
+        return None
+
+    for attempt_num in range(1, attempts + 1):
+        if attempt_num < attempts / 2:
+            logger.debug("Attempt %d/%d to get AXFR for %s", attempt_num, attempts, zone_str)
+        else:
+            logger.warning("Attempt %d/%d to get AXFR for %s", attempt_num, attempts, zone_str)
+        try:
+            keyring = None
+            algorithm = None
+            if tsig_key_name and tsig_secret:
+                keyring = dns.tsigkeyring.from_text({tsig_key_name: tsig_secret})
+                algorithm = tsig_algorithm if tsig_algorithm else "hmac-sha256"
+            axfr = dns.query.xfr(
+                where=nameserver_ip,
+                port=port,
+                zone=zone_str,
+                keyring=keyring,
+                keyname=tsig_key_name,
+                keyalgorithm=algorithm,
+                relativize=False,
+                lifetime=30,
+            )
+            zone = dns.zone.from_xfr(axfr, relativize=False)
+            logger.debug("Got the AXFR for %s", zone_str)
+            return zone
+        except (EOFError, ConnectionError):
+            logger.exception("Connection failed while getting zone %s, attempt %d/%d", zone_str, attempt_num, attempts)
+        except dns.query.TransferError as exc:
+            if exc.rcode == dns.rcode.NOTAUTH:
+                logger.error("AXFR refused (NOTAUTH) for zone %s from %s, check server ACLs or TSIG config", zone_str, nameserver)
+            else:
+                logger.exception("Unable to get zone %s, skipping", zone_str)
+            return None
+
+    logger.warning("Unable to get AXFR for %s", zone_str)
+    return None
+
+
+def get_zones_from_catalog(catalog_zone) -> list[str]:
+    """
+    Extract member zone names from a DNS catalog zone.
+
+    Catalog zones typically store members as PTR records under
+    ``*.zones.<catalog-origin>``.
+    """
+    zones = set()
+    zones_subtree = dns.name.from_text("zones", catalog_zone.origin)
+
+    for name, node in catalog_zone.nodes.items():
+        owner_fqdn = name.derelativize(catalog_zone.origin)
+        if not owner_fqdn.is_subdomain(zones_subtree):
+            continue
+
+        for rdataset in node.rdatasets:
+            if rdataset.rdtype != dns.rdatatype.PTR:
+                continue
+
+            for rdata in rdataset:
+                zone_name = rdata.target.to_text().rstrip(".")
+                if zone_name:
+                    zones.add(zone_name)
+
+    return sorted(zones)
+
+
+def run(axfr_source) -> list[dns.zone.Zone]:
+    """Run auror_hostnames module"""
+    dns_server = axfr_source["dns_server"]
+    port = axfr_source.get("port", 53)
+    catalog_zone_name = axfr_source.get("catalog_zone_name")
+    list_of_zones = axfr_source.get("list_of_zones", [])
+    tsig_key_name = axfr_source.get("tsig_key_name") or None
+    tsig_secret = axfr_source.get("tsig_secret") or None
+    tsig_algorithm = axfr_source.get("tsig_algorithm") or None
+    zones = []
+
+    if catalog_zone_name:
+        catalog_zone = query_zone(dns_server, catalog_zone_name, tsig_key_name, tsig_secret, tsig_algorithm, port=port)
+        if catalog_zone:
+            list_of_zones = get_zones_from_catalog(catalog_zone)
+
+    for zone_str in list_of_zones:
+        zone = query_zone(dns_server, zone_str, tsig_key_name, tsig_secret, tsig_algorithm, port=port)
+        if zone:
+            zones.append(zone)
+
+    return zones

--- a/server/sner/plugin/auror_hostnames/core.py
+++ b/server/sner/plugin/auror_hostnames/core.py
@@ -6,45 +6,16 @@ import json
 import logging
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from socket import getaddrinfo
 
 import dns.rdatatype
 import dns.zone
 
+from sner.plugin.auror_hostnames import axfr, git, http
+from sner.plugin.auror_hostnames.manager import AgreegateManager
+
 logger = logging.getLogger(__name__)
-
-
-def get_repos(git_server, git_key_path) -> list:
-    """
-    Get DNS repositories from git server
-    """
-    cmd = ["ssh", "-i", git_key_path, f"git@{git_server}", "info"]
-    output = subprocess.check_output(cmd, text=True).splitlines()[2:]  # Skip the first line
-    repos = [line.split("\t")[-1] for line in output]
-
-    return repos
-
-
-def clone_dns_repos(git_server, repos, git_key_path):
-    """Clone DNS zones from git repository"""
-    env = os.environ.copy()
-    env["GIT_SSH_COMMAND"] = f"ssh -i {git_key_path}"
-    for repo in repos:
-        subprocess.run(["git", "clone", f"git@{git_server}:{repo}", f"dns-zones/{repo}"], check=True, env=env)
-
-
-def get_zone_file_paths() -> set:
-    """
-    Get DNS zone names from git repos
-    """
-    repos_folder = Path("dns-zones")
-    zone_file_paths = set()
-    for zone_file in repos_folder.glob("**/*.zone"):
-        zone_file_paths.add(str(zone_file))
-
-    return zone_file_paths
 
 
 def process_cnames(cnames, a_aaaa, ip_hostnames) -> dict:
@@ -100,7 +71,7 @@ def process_cnames(cnames, a_aaaa, ip_hostnames) -> dict:
     return ip_hostnames
 
 
-def resolve_hostname(hostname):
+def resolve_hostname(hostname) -> list:
     """Resolve hostname to IP address
     Args:
         hostname (str): hostname
@@ -141,7 +112,7 @@ def process_ptrs(ptrs, ip_hostnames) -> dict:
     return ip_hostnames
 
 
-def check_if_hostname(hostname):
+def check_if_hostname(hostname) -> bool:
     """Check if hostname is valid
 
     Args:
@@ -155,7 +126,7 @@ def check_if_hostname(hostname):
     return True
 
 
-def create_fqdn(record_string, origin):
+def create_fqdn(record_string, origin) -> str:
     """Create FQDN from record
 
     Args:
@@ -171,26 +142,10 @@ def create_fqdn(record_string, origin):
     return fqdn
 
 
-def get_records(zone_file_path) -> list:  # pylint: disable=too-many-locals
+def parse_zone(zone, origin) -> list:
     """
-    Gets A and AAAA records and stores them in the format {IP1: [hostname1, hostname2], IP2: [hostname1, hostname3]}
+    Parse a dns.zone.Zone object and extract CNAME, A/AAAA, PTR, and IP-hostname mappings.
     """
-    with open(zone_file_path, encoding="utf-8") as zone_file:
-        try:
-            zone = dns.zone.from_file(zone_file)
-            origin = zone.origin.to_text()[:-1]
-        except dns.zone.UnknownOrigin:
-            zone_file_name = zone_file_path.split("/")[-1]
-            origin = os.path.splitext(zone_file_name)[0]
-            try:
-                zone = dns.zone.from_file(zone_file, origin)
-            except Exception as error:  # pylint: disable=broad-exception-caught
-                logger.error("Exception occurred during parsing zone file %s: %s}", zone_file_path, error)
-                return [{}, {}, {}, {}]
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logger.error("Exception occurred during parsing zone file %s: %s}", zone_file_path, error)
-            return [{}, {}, {}, {}]
-
     cnames = {}
     a_aaaa = {}
     ptrs = {}
@@ -212,42 +167,114 @@ def get_records(zone_file_path) -> list:  # pylint: disable=too-many-locals
                             a_aaaa.setdefault(fqdn, set()).add(rdata_string)
                         elif rdatatype == dns.rdatatype.PTR:
                             ptrs[fqdn] = rdata_string
-
     return [cnames, a_aaaa, ptrs, ip_hostnames]
 
 
-def check_git_key_path(git_key_path):
-    """Check if git key path exists"""
-    if not os.path.exists(git_key_path):
-        return False
-    return True
+def get_records_from_file(zone_file_path) -> list:
+    """
+    Loads a zone file and parses its records.
+    """
+    with open(zone_file_path, encoding="utf-8") as zone_file:
+        try:
+            zone = dns.zone.from_file(zone_file)
+            origin = zone.origin.to_text()[:-1]
+        except dns.zone.UnknownOrigin:
+            zone_file_name = zone_file_path.split("/")[-1]
+            origin = os.path.splitext(zone_file_name)[0]
+            try:
+                zone = dns.zone.from_file(zone_file, origin)
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error("Exception occurred during parsing zone file %s: %s}", zone_file_path, error)
+                return [{}, {}, {}, {}]
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.error("Exception occurred during parsing zone file %s: %s}", zone_file_path, error)
+            return [{}, {}, {}, {}]
+    return parse_zone(zone, origin)
 
 
-def run(assignment):  # pragma: no cover
-    """Run auror_hostnames module"""
+def get_records_from_zone(zone) -> list:
+    """
+    Parses a dns.zone.Zone object (e.g., from AXFR).
+    """
+    origin = zone.origin.to_text()[:-1]
+    return parse_zone(zone, origin)
 
-    git_key_path = assignment["config"]["git_key_path"]
-    git_server = assignment["config"]["git_server"]
 
-    if check_git_key_path(git_key_path) is False:
-        logger.error("Git key file does not exist")
-        return 1
+def collect_dns_sources(agreegate, groups) -> tuple:
+    """Collect DNS sources from groups
 
-    repos = get_repos(git_server, git_key_path)
-    clone_dns_repos(git_server, repos, git_key_path)
-    zone_file_paths = get_zone_file_paths()
+    Args:
+        agreegate: AgreegateManager instance
+        groups: List of groups with DNS sources
 
+    Returns:
+        tuple: (dns_sources, axfr_sources, http_sources)
+    """
+    dns_sources = []
+    for group in groups:
+        dns_sources.extend(agreegate.get_group_dns_sources(group.id))
+
+    axfr_sources = [source for source in dns_sources if source["type"] == "AXFR"]
+    http_sources = [source for source in dns_sources if source["type"] == "HTTPS"]
+
+    return dns_sources, axfr_sources, http_sources
+
+
+def gather_zone_data(assignment, http_sources, axfr_sources):
+    """Gather zone data from all sources
+
+    Args:
+        assignment: The assignment configuration
+        http_sources: List of HTTP sources
+        axfr_sources: List of AXFR sources
+
+    Returns:
+        tuple: (zone_file_paths, zones)
+    """
+    zone_file_paths = []
+    if assignment["config"].get("git_server"):
+        zone_file_paths = git.run(assignment)
+
+    for http_source in http_sources:
+        zone_file_paths += http.run(http_source)
+
+    zones = []
+    for axfr_source in axfr_sources:
+        zones += axfr.run(axfr_source)
+
+    return zone_file_paths, zones
+
+
+def write_output(ip_hostnames):
+    """Write the final output to JSON file"""
+    if Path("dns-zones").exists():
+        shutil.rmtree("dns-zones")
+    Path("output.json").write_text(json.dumps(ip_hostnames, indent=4), encoding="utf-8")
+
+
+def build_ip_hostnames(zone_file_paths, zones) -> dict:
+    """Process and merge zone files and zones into the final ip -> hostnames mapping.
+
+    Args:
+        zone_file_paths: List of zone file paths (from git/https sources)
+        zones: List of dns.zone.Zone objects (from AXFR sources)
+
+    Returns:
+        dict: { ip: [hostname, ...] }
+    """
     cnames = {}
     a_aaaa = {}
     ptrs = {}
     ip_hostnames = {}
 
-    for zone_file_path in zone_file_paths:
-        result = get_records(zone_file_path)
-        cnames.update(result[0])
-        a_aaaa.update(result[1])
-        ptrs.update(result[2])
-        ip_hostnames.update(result[3])
+    parsed_records = [get_records_from_file(path) for path in zone_file_paths]
+    parsed_records += [get_records_from_zone(zone) for zone in zones]
+    for records in parsed_records:
+        cnames.update(records[0])
+        a_aaaa.update(records[1])
+        ptrs.update(records[2])
+        for ip_addr, hostnames in records[3].items():
+            ip_hostnames.setdefault(ip_addr, set()).update(hostnames)
 
     logger.info("Found %s CNAME records", len(cnames))
     logger.info("Found %s A/AAAA records", len(a_aaaa))
@@ -255,10 +282,20 @@ def run(assignment):  # pragma: no cover
 
     ip_hostnames = process_ptrs(ptrs, ip_hostnames)
     ip_hostnames = process_cnames(cnames, a_aaaa, ip_hostnames)
-    ip_hostnames = {k: list(v) for k, v in ip_hostnames.items()}
+    return {k: list(v) for k, v in ip_hostnames.items()}
+
+
+def run(assignment):
+    """Run auror_hostnames module"""
+
+    agreegate = AgreegateManager.from_env()
+    groups = agreegate.get_all_groups(only_with_dns_source=True)
+    _, axfr_sources, http_sources = collect_dns_sources(agreegate, groups)
+
+    zone_file_paths, zones = gather_zone_data(assignment, http_sources, axfr_sources)
+    ip_hostnames = build_ip_hostnames(zone_file_paths, zones)
 
     logger.info("Found hostnames for %s IP addresses", len(ip_hostnames))
 
-    shutil.rmtree("dns-zones")
-    Path("output.json").write_text(json.dumps(ip_hostnames, indent=4), encoding="utf-8")
+    write_output(ip_hostnames)
     return 0

--- a/server/sner/plugin/auror_hostnames/decompress.py
+++ b/server/sner/plugin/auror_hostnames/decompress.py
@@ -1,0 +1,34 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""archive decompression related functions for auror_hostnames plugin"""
+
+import io
+import logging
+import os
+import zipfile
+
+logger = logging.getLogger(__name__)
+
+
+def extract_zone_files(archive_bytes) -> list[str]:
+    """Extract zone files from a plain (non-encrypted) zip archive."""
+
+    if not archive_bytes:
+        return []
+
+    logger.info("Extracting zone files from the archive")
+    buf = io.BytesIO(archive_bytes)
+
+    if not zipfile.is_zipfile(buf):
+        logger.error("Unable to detect archive format")
+        return []
+
+    buf.seek(0)
+    try:
+        with zipfile.ZipFile(buf) as zipf:
+            zone_names = [n for n in zipf.namelist() if n.endswith(".zone")]
+            for name in zone_names:
+                zipf.extract(name, "dns-zones")
+            return [os.path.join("dns-zones", n) for n in zone_names]
+    except (zipfile.BadZipFile, RuntimeError) as e:
+        logger.error("Failed to extract zip archive: %s", e)
+        return []

--- a/server/sner/plugin/auror_hostnames/git.py
+++ b/server/sner/plugin/auror_hostnames/git.py
@@ -1,0 +1,65 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""git related functions for auror_hostnames plugin"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def check_git_key_path(git_key_path) -> bool:
+    """Check if git key path exists"""
+    return os.path.exists(git_key_path)
+
+
+def get_repos(git_server, git_key_path) -> list:
+    """
+    Get DNS repositories from git server
+    """
+    cmd = ["ssh", "-i", git_key_path, f"git@{git_server}", "info"]
+    output = subprocess.check_output(cmd, text=True).splitlines()[2:]  # Skip the first line
+    repos = [line.split("\t")[-1] for line in output]
+
+    return repos
+
+
+def clone_dns_repos(git_server, repos, git_key_path):
+    """Clone DNS zones from git repository"""
+    env = os.environ.copy()
+    env["GIT_SSH_COMMAND"] = f"ssh -i {git_key_path}"
+    for repo in repos:
+        subprocess.run(["git", "clone", f"git@{git_server}:{repo}", f"dns-zones/{repo}"], check=True, env=env)
+
+
+def get_zone_file_paths() -> set:
+    """
+    Get DNS zone names from git repos
+    """
+    repos_folder = Path("dns-zones")
+    zone_file_paths = set()
+    for zone_file in repos_folder.glob("**/*.zone"):
+        zone_file_paths.add(str(zone_file))
+
+    return sorted(zone_file_paths)
+
+
+def run(assignment):
+    """Run auror_hostnames module"""
+
+    git_key_path = assignment["config"]["git_key_path"]
+    git_server = assignment["config"]["git_server"]
+
+    if check_git_key_path(git_key_path) is False:
+        logger.error("Git key file does not exist")
+        return []
+
+    try:
+        repos = get_repos(git_server, git_key_path)
+        clone_dns_repos(git_server, repos, git_key_path)
+        zone_file_paths = get_zone_file_paths()
+        return zone_file_paths
+    except (OSError, subprocess.CalledProcessError):
+        logger.exception("Failed to load DNS zone files from git")
+        return []

--- a/server/sner/plugin/auror_hostnames/http.py
+++ b/server/sner/plugin/auror_hostnames/http.py
@@ -1,0 +1,38 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""http related functions for auror_hostnames plugin"""
+
+import logging
+
+import requests
+
+from sner.plugin.auror_hostnames.decompress import extract_zone_files
+
+logger = logging.getLogger(__name__)
+
+
+def download_zone_archive(url, auth=None) -> bytes | None:
+    """Download the zone archive from the given URL"""
+
+    try:
+        response = requests.get(url, auth=auth, timeout=30)
+        response.raise_for_status()
+        return response.content
+    except requests.RequestException as e:
+        logger.error("Failed to download zone archive from %s: %s", url, e)
+        return None
+
+
+def run(http_source) -> list[str]:
+    """Run auror_hostnames module"""
+    http_server_url = http_source.get("http_url")
+    username = http_source.get("http_auth_login") or None
+    password = http_source.get("http_auth_password") or None
+    auth = (username, password) if username and password else None
+    archive_bytes = download_zone_archive(http_server_url, auth=auth)
+
+    if not archive_bytes:
+        logger.warning("No archive bytes returned for %s", http_server_url)
+        return []
+
+    zone_file_paths = extract_zone_files(archive_bytes)
+    return zone_file_paths

--- a/server/sner/plugin/auror_hostnames/manager.py
+++ b/server/sner/plugin/auror_hostnames/manager.py
@@ -1,0 +1,89 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+sner auror_hostnames agreegate api manager module
+"""
+
+import os
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+
+class AgreegateApiError(Exception):
+    """agreegate api call or payload validation error"""
+
+
+class Group(BaseModel):
+    """Group model returned by AgreeGate API"""
+
+    id: int
+    name: str
+    description: str | None = None
+    external_id: str | None = None
+    allowed_networks: list[str] = Field(default_factory=list)
+
+
+GROUPS_RESPONSE_ADAPTER = TypeAdapter(list[Group])
+DNS_SOURCES_RESPONSE_ADAPTER = TypeAdapter(list[dict[str, Any]])
+
+
+class AgreegateManager:
+    """AgreeGate API client for the auror_hostnames plugin"""
+
+    def __init__(self, url, apikey):
+        self.url = url.rstrip("/")
+        self.apikey = apikey
+
+    @classmethod
+    def from_env(cls, url_envname="SNER_AGREEGATE_URL", apikey_envname="SNER_AGREEGATE_APIKEY"):
+        """factory, initialize from environment variables"""
+
+        url = os.environ.get(url_envname)
+        apikey = os.environ.get(apikey_envname)
+        if not url:
+            raise AgreegateApiError(f"missing {url_envname} environment variable")
+        if not apikey:
+            raise AgreegateApiError(f"missing {apikey_envname} environment variable")
+        return cls(url, apikey)
+
+    def apicall(self, method, url, **kwargs):
+        """make an authenticated AgreeGate API call and return decoded JSON body"""
+
+        response = requests.request(
+            method,
+            f"{self.url}{url}",
+            headers={"X-API-KEY": self.apikey},
+            timeout=60,
+            **kwargs,
+        )
+
+        if response.status_code != HTTPStatus.OK:
+            raise AgreegateApiError(f"agreegate apicall failed, status={response.status_code}, body={response.text}")
+
+        return response.json()
+
+    def get_all_groups(self, only_with_dns_source=False):
+        """fetch and validate all groups"""
+
+        response_json = self.apicall("GET", "/api/v1/groups", params={"only_with_dns_source": only_with_dns_source})
+        try:
+            return GROUPS_RESPONSE_ADAPTER.validate_python(response_json)
+        except ValidationError as exc:
+            raise AgreegateApiError(f"groups response validation failed: {exc}") from exc
+
+    def get_group_dns_sources(self, group_id):
+        """fetch and validate DNS sources for a required group_id"""
+
+        if group_id is None or str(group_id).strip() == "":
+            raise ValueError("group_id is required")
+
+        group_id_escaped = quote(str(group_id), safe="")
+        response_json = self.apicall("GET", f"/api/v1/group/{group_id_escaped}/dns_sources")
+        sources = response_json.get("dns_sources", response_json) if isinstance(response_json, dict) else response_json
+        try:
+            return DNS_SOURCES_RESPONSE_ADAPTER.validate_python(sources)
+        except ValidationError as exc:
+            raise AgreegateApiError(f"group dns_sources response validation failed: {exc}") from exc

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -32,12 +32,14 @@ def app():
     _app = create_app(config_file="tests/sner.yaml", config_env="dummy")
 
     with _app.app_context():
+        os.makedirs(_app.config["SNER_VAR"], exist_ok=True)
         db_remove()
         db.create_all()
 
     yield _app
 
     with _app.app_context():
+        os.makedirs(_app.config["SNER_VAR"], exist_ok=True)
         db_remove()
 
 

--- a/server/tests/plugin/auror_hostnames/conftest.py
+++ b/server/tests/plugin/auror_hostnames/conftest.py
@@ -1,0 +1,178 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin shared fixtures
+"""
+
+import os
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+import dns.message
+import dns.name
+import dns.rcode
+import dns.rdatatype
+import dns.rrset
+import dns.zone
+import pytest
+
+
+class AxfrServer:
+    """minimal in-process TCP DNS server answering AXFR queries for configured zones"""
+
+    def __init__(self):
+        self.zones = {}
+        self.keyring = None
+        self.response_rcode = None
+        self.fail_connections = 0
+        self.sock = socket.socket()
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(5)
+        self._shutdown = False
+        self.thread = threading.Thread(target=self._serve_loop, daemon=True)
+        self.thread.start()
+
+    @property
+    def port(self):
+        """port the server listens on"""
+        return self.sock.getsockname()[1]
+
+    def add_zone(self, zone_text, origin):
+        """register a zone served for AXFR queries"""
+        self.zones[dns.name.from_text(origin)] = dns.zone.from_text(zone_text, origin=origin, relativize=False, check_origin=False)
+
+    def stop(self):
+        """shutdown the server, waking up the accept loop with a dummy connection"""
+        self._shutdown = True
+        socket.create_connection(("127.0.0.1", self.port), timeout=5).close()
+        self.sock.close()
+        self.thread.join(timeout=5)
+
+    def _serve_loop(self):
+        while True:
+            conn, _ = self.sock.accept()
+            conn.settimeout(5)
+            if self._shutdown:
+                conn.close()
+                return
+            try:
+                self._handle(conn)
+            except Exception:  # pylint: disable=broad-exception-caught  ; queries for unknown zones just drop the connection
+                pass
+            finally:
+                conn.close()
+
+    def _handle(self, conn):
+        length = int.from_bytes(self._read(conn, 2), "big")
+        wire = self._read(conn, length)
+
+        # closing the connection without a reply drives the client EOFError retry path
+        if self.fail_connections > 0:
+            self.fail_connections -= 1
+            return
+
+        query = dns.message.from_wire(wire, keyring=self.keyring)
+        response = dns.message.make_response(query)
+
+        if self.response_rcode is not None:
+            response.set_rcode(self.response_rcode)
+        else:
+            zone = self.zones[query.question[0].name]
+            soa_rdataset = zone.find_rdataset(zone.origin, dns.rdatatype.SOA)
+            soa_rrset = dns.rrset.from_rdata_list(zone.origin, soa_rdataset.ttl, list(soa_rdataset))
+            answer = [soa_rrset]
+            for name, rdataset in zone.iterate_rdatasets():
+                if rdataset.rdtype != dns.rdatatype.SOA:
+                    answer.append(dns.rrset.from_rdata_list(name, rdataset.ttl, list(rdataset)))
+            answer.append(soa_rrset)
+            response.answer = answer
+
+        if self.keyring:
+            response.use_tsig(self.keyring)
+
+        wire = response.to_wire()
+        conn.sendall(len(wire).to_bytes(2, "big") + wire)
+
+    @staticmethod
+    def _read(conn, size):
+        data = b""
+        while len(data) < size:
+            chunk = conn.recv(size - len(data))
+            if not chunk:
+                raise ConnectionError("client disconnected")
+            data += chunk
+        return data
+
+
+@pytest.fixture
+def axfr_server():
+    """in-process AXFR-capable DNS server"""
+
+    server = AxfrServer()
+    yield server
+    server.stop()
+
+
+GIT_ZONE_TEXT = """
+$ORIGIN {origin}.
+$TTL 300
+@ IN SOA ns1.{origin}. admin.{origin}. 1 3600 900 604800 300
+@ IN NS ns1.{origin}.
+www IN A {address}
+"""
+
+GITOLITE_REPOS = {"zones/repo1": ("git1.example.com", "192.0.2.11"), "zones/repo2": ("git2.example.com", "192.0.2.12")}
+
+SSH_SHIM = """\
+#!/bin/sh
+# fake gitolite ssh for tests; second-to-last argument is git@<server>, last is the remote command
+prev=""
+for arg in "$@"; do server="$prev"; prev="$arg"; done
+cmd="$prev"
+
+if [ "$server" = "git@fail.example.com" ]; then
+    exit 255
+fi
+
+if [ "$cmd" = "info" ]; then
+    printf 'hello tester, this is gitolite\\nyou have access to:\\n R W\\tzones/repo1\\n R W\\tzones/repo2\\n'
+    exit 0
+fi
+
+# cmd is "git-upload-pack 'zones/repo1'", delegate to the local bare repository
+eval "set -- $cmd"
+exec "$1" "GITOLITE_BASE/$2"
+"""
+
+
+def create_bare_repo(base_path, repo_name, origin, address):
+    """create local bare git repository with a zone file"""
+
+    src_path = base_path / "src" / repo_name
+    src_path.mkdir(parents=True)
+    (src_path / f"{origin}.zone").write_text(GIT_ZONE_TEXT.format(origin=origin, address=address), encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=src_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=src_path, check=True)
+    subprocess.run(["git", "-c", "user.email=test@test", "-c", "user.name=test", "commit", "-q", "-m", "initial"], cwd=src_path, check=True)
+    subprocess.run(["git", "clone", "-q", "--bare", str(src_path), str(base_path / repo_name)], check=True)
+
+
+@pytest.fixture
+def gitolite_server(tmpworkdir, monkeypatch):
+    """fake gitolite server; local bare repositories accessed through an ssh shim placed on PATH"""
+
+    base_path = Path(tmpworkdir) / "gitolite"
+    for repo, (origin, address) in GITOLITE_REPOS.items():
+        create_bare_repo(base_path, repo, origin, address)
+
+    bin_path = Path(tmpworkdir) / "bin"
+    bin_path.mkdir()
+    shim_path = bin_path / "ssh"
+    shim_path.write_text(SSH_SHIM.replace("GITOLITE_BASE", str(base_path)), encoding="utf-8")
+    shim_path.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_path}{os.pathsep}{os.environ['PATH']}")
+
+    key_path = Path(tmpworkdir) / "gitkey"
+    key_path.write_text("dummy key", encoding="utf-8")
+    yield {"git_key_path": str(key_path), "git_server": "git.example.com"}

--- a/server/tests/plugin/auror_hostnames/test_axfr.py
+++ b/server/tests/plugin/auror_hostnames/test_axfr.py
@@ -1,0 +1,151 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin axfr tests
+"""
+
+import logging
+
+import dns.name
+import dns.rcode
+import dns.rdatatype
+import dns.tsigkeyring
+import dns.zone
+
+from sner.plugin.auror_hostnames.axfr import get_zones_from_catalog, query_zone, run
+
+EXAMPLE_ZONE_TEXT = """
+@ 300 IN SOA ns1.example.com. admin.example.com. 1 3600 900 604800 300
+@ 300 IN NS ns1.example.com.
+ns1 300 IN A 192.0.2.1
+www 300 IN A 192.0.2.3
+www 300 IN AAAA 2001:db8::3
+"""
+
+CATALOG_ZONE_TEXT = """
+@ 300 IN SOA invalid. invalid. 1 3600 900 604800 300
+@ 300 IN NS invalid.
+version 300 IN TXT "2"
+unique1.zones 300 IN PTR example.com.
+unique2.zones 300 IN PTR beta.example.com.
+nonptr.zones 300 IN TXT "not a member"
+emptyname.zones 300 IN PTR .
+"""
+
+TSIG_KEY_NAME = "tsig-key."
+TSIG_SECRET = "MTIzNDU2Nzg5MGFiY2RlZg=="
+
+
+def test_query_zone(axfr_server):
+    """query_zone transfers the zone from the server"""
+
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+
+    zone = query_zone("127.0.0.1", "example.com", port=axfr_server.port)
+
+    assert zone.origin.to_text() == "example.com."
+    assert zone.get_rdataset(dns.name.from_text("www.example.com."), dns.rdatatype.A)
+
+
+def test_query_zone_with_tsig(axfr_server):
+    """query_zone transfers the zone using TSIG authentication, with default and explicit algorithm"""
+
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+    axfr_server.keyring = dns.tsigkeyring.from_text({TSIG_KEY_NAME: TSIG_SECRET})
+
+    zone = query_zone("127.0.0.1", "example.com", TSIG_KEY_NAME, TSIG_SECRET, port=axfr_server.port)
+    assert zone.origin.to_text() == "example.com."
+
+    zone = query_zone("127.0.0.1", "example.com", TSIG_KEY_NAME, TSIG_SECRET, "hmac-sha256", port=axfr_server.port)
+    assert zone.origin.to_text() == "example.com."
+
+
+def test_query_zone_unresolvable_nameserver():
+    """query_zone returns None when the nameserver hostname cannot be resolved"""
+
+    assert query_zone("unresolvable.invalid", "example.com") is None
+
+
+def test_query_zone_retries_on_connection_failure(axfr_server):
+    """query_zone retries when the server drops the connection and succeeds on a later attempt"""
+
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+    axfr_server.fail_connections = 1
+
+    zone = query_zone("127.0.0.1", "example.com", attempts=2, port=axfr_server.port)
+
+    assert zone.origin.to_text() == "example.com."
+
+
+def test_query_zone_fails_after_all_attempts(axfr_server):
+    """query_zone returns None when all attempts fail"""
+
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+    axfr_server.fail_connections = 2
+
+    assert query_zone("127.0.0.1", "example.com", attempts=2, port=axfr_server.port) is None
+
+
+def test_query_zone_transfer_refused(axfr_server):
+    """query_zone returns None when the server responds with an error rcode"""
+
+    axfr_server.response_rcode = dns.rcode.REFUSED
+
+    assert query_zone("127.0.0.1", "example.com", port=axfr_server.port) is None
+
+
+def test_query_zone_transfer_notauth(axfr_server, caplog):
+    """query_zone returns None and logs a distinct message when the server responds NOTAUTH"""
+
+    axfr_server.response_rcode = dns.rcode.NOTAUTH
+
+    with caplog.at_level(logging.ERROR, logger="sner.plugin.auror_hostnames.axfr"):
+        result = query_zone("127.0.0.1", "example.com", port=axfr_server.port)
+
+    assert result is None
+    assert any("NOTAUTH" in record.message for record in caplog.records)
+
+
+def test_get_zones_from_catalog():
+    """get_zones_from_catalog returns sorted member zones from PTR records under the zones subtree"""
+
+    catalog_zone = dns.zone.from_text(CATALOG_ZONE_TEXT, origin="catalog.example.", check_origin=False)
+
+    assert get_zones_from_catalog(catalog_zone) == ["beta.example.com", "example.com"]
+
+
+def test_run_with_list_of_zones(axfr_server):
+    """run transfers all configured zones, skipping the failed ones"""
+
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+
+    zones = run(
+        {
+            "dns_server": "127.0.0.1",
+            "port": axfr_server.port,
+            "list_of_zones": ["example.com", "missing.example.com"],
+        }
+    )
+
+    assert [zone.origin.to_text() for zone in zones] == ["example.com."]
+
+
+def test_run_with_catalog_zone(axfr_server):
+    """run discovers member zones from the catalog zone and transfers them with TSIG"""
+
+    axfr_server.add_zone(CATALOG_ZONE_TEXT, "catalog.example.")
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "example.com.")
+    axfr_server.add_zone(EXAMPLE_ZONE_TEXT, "beta.example.com.")
+    axfr_server.keyring = dns.tsigkeyring.from_text({TSIG_KEY_NAME: TSIG_SECRET})
+
+    zones = run(
+        {
+            "dns_server": "127.0.0.1",
+            "port": axfr_server.port,
+            "catalog_zone_name": "catalog.example",
+            "tsig_key_name": TSIG_KEY_NAME,
+            "tsig_secret": TSIG_SECRET,
+            "tsig_algorithm": "hmac-sha256",
+        }
+    )
+
+    assert sorted(zone.origin.to_text() for zone in zones) == ["beta.example.com.", "example.com."]

--- a/server/tests/plugin/auror_hostnames/test_core.py
+++ b/server/tests/plugin/auror_hostnames/test_core.py
@@ -3,125 +3,97 @@
 auror_hostnames plugin core tests
 """
 
+import io
+import json
+import zipfile
 from pathlib import Path
-from unittest.mock import call, patch
 
 import dns.zone
 import pytest
 
+from sner.plugin.auror_hostnames import core as core_module
 from sner.plugin.auror_hostnames.core import (
-    check_git_key_path,
+    build_ip_hostnames,
     check_if_hostname,
-    clone_dns_repos,
+    collect_dns_sources,
     create_fqdn,
-    get_records,
-    get_repos,
-    get_zone_file_paths,
+    get_records_from_file,
+    get_records_from_zone,
     process_cnames,
     process_ptrs,
     resolve_hostname,
+    run,
+    write_output,
 )
+from sner.plugin.auror_hostnames.manager import AgreegateManager
 
-dummy_repos = ["dummy_repo1", "dummy_repo2", "dummy_repo3"]
-key = "dummy_key"
-server = "dummy_domain.com"
 test_files_path = "tests/server/data/auror_hostnames-dns_zones"
 dns_zones_folder = "dns-zones"
 zone_file_path1 = f"{test_files_path}/{dns_zones_folder}/dummy_repo1/zones/example.com.zone"
 zone_file_path2 = f"{test_files_path}/{dns_zones_folder}/dummy_repo2/zones/1.168.192.in-addr.arpa.zone"
 
+AXFR_ZONE_TEXT = """
+@ 300 IN SOA ns1.axfr.example.com. admin.axfr.example.com. 1 3600 900 604800 300
+@ 300 IN NS ns1.axfr.example.com.
+www 300 IN A 192.0.2.31
+alias 300 IN CNAME www.axfr.example.com.
+"""
 
-def test_get_repos():
-    """Test getting DNS repositories"""
-    output_file_path = "tests/server/data/auror_hostnames-gitolite_output"
-    with open(output_file_path, encoding="utf-8") as file:
-        mock_output = file.read()
-    with patch("subprocess.check_output", return_value=mock_output):
-        result = get_repos(server, key)
-
-    assert result == dummy_repos
-
-
-def test_clone_dns_repos():
-    """Test cloning DNS repo"""
-    dummy_git_server = "dummy_git_server"
-
-    # Mock the subprocess.run to simulate cloning
-    with patch("subprocess.run") as mock_run:
-        clone_dns_repos(dummy_git_server, dummy_repos, key)
-
-        # Check if subprocess.run was called with the correct arguments
-        expected_calls = [call(["git", "clone", f"git@{dummy_git_server}:{repo}", f"{dns_zones_folder}/{repo}"]) for repo in dummy_repos]
-        actual_calls = [call(*args) for args, _ in mock_run.call_args_list]
-        assert actual_calls == expected_calls
+HTTPS_ZONE_TEXT = """
+$ORIGIN https.example.com.
+$TTL 300
+@ IN SOA ns1.https.example.com. admin.https.example.com. 1 3600 900 604800 300
+@ IN NS ns1.https.example.com.
+www IN A 192.0.2.21
+"""
 
 
-def test_get_zone_file_paths():
-    """Test getting zone file paths"""
-
-    with patch("sner.plugin.auror_hostnames.core.Path", return_value=Path(f"{test_files_path}/{dns_zones_folder}")):
-        result = get_zone_file_paths()
-
-    expected_result = {
-        f"{test_files_path}/{dns_zones_folder}/dummy_repo1/zones/example.com.zone",
-        f"{test_files_path}/{dns_zones_folder}/dummy_repo2/zones/1.168.192.in-addr.arpa.zone",
-        f"{test_files_path}/{dns_zones_folder}/dummy_repo3/zones/8.b.d.0.1.0.0.2.ip6.arpa.zone",
-    }
-    assert result == expected_result
-
-
-def test_process_cnames():
+def test_process_cnames(monkeypatch):
     """Test processing CNAMEs"""
+
     cnames = {"alias1": "cname1", "alias2": "cname2"}
     cnames_loop = {"alias1": "alias2", "alias2": "alias3", "alias3": "alias1"}
     a_aaaa = {"cname1": ["1.1.1.1"]}
     ip_hostnames = {"1.1.1.1": {"cname1"}}
 
-    with patch("sner.plugin.auror_hostnames.core.resolve_hostname") as mock_resolve_hostname:
-        mock_resolve_hostname.side_effect = lambda hostname: {
-            "cname1": ["1.1.1.1"],
-            "cname2": ["2.2.2.2"],
-            "alias1": ["1.1.1.1"],
-            "alias2": ["2.2.2.2"],
-        }.get(hostname, [])
+    addresses = {"cname2": "2.2.2.2", "alias2": "2.2.2.2"}
+    monkeypatch.setattr(core_module, "getaddrinfo", lambda hostname, port: [(2, 1, 6, "", (addresses[hostname], 0))])
 
-        result = process_cnames(cnames, a_aaaa, ip_hostnames)
-    expected_result = {
+    result = process_cnames(cnames, a_aaaa, ip_hostnames)
+
+    assert result == {
         "1.1.1.1": {"alias1", "cname1"},
         "2.2.2.2": {"alias2", "cname2"},
     }
-    assert result == expected_result
-    mock_resolve_hostname.assert_any_call("cname2")
-    mock_resolve_hostname.assert_any_call("alias2")
+
     with pytest.raises(ValueError, match="CNAME chain loop detected"):
         process_cnames(cnames_loop, a_aaaa, ip_hostnames)
 
 
-def test_resolve_hostname():
+def test_resolve_hostname(monkeypatch):
     """Test resolving hostname"""
-    hostname = "example.com"
-    expected_ips = ["93.184.216.34"]
 
-    with patch("sner.plugin.auror_hostnames.core.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
-        result = resolve_hostname(hostname)
-        assert result == expected_ips
+    monkeypatch.setattr(core_module, "getaddrinfo", lambda hostname, port: [(2, 1, 6, "", ("93.184.216.34", 0))])
+    assert resolve_hostname("example.com") == ["93.184.216.34"]
 
-    with patch("sner.plugin.auror_hostnames.core.getaddrinfo", side_effect=OSError):
-        result = resolve_hostname("invalid-hostname")
-        assert result == []
+    def getaddrinfo_error(hostname, port):
+        raise OSError
+
+    monkeypatch.setattr(core_module, "getaddrinfo", getaddrinfo_error)
+    assert resolve_hostname("invalid-hostname") == []
 
 
 def test_process_ptrs():
     """Test processing PTRs"""
+
     ptrs = {
         "1.1.1.1.in-addr.arpa": "hostname1.",
         "2.2.2.2.in-addr.arpa": "hostname2.",
         "3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.ip6.arpa": "hostname3.",
         "4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.ip6.arpa": "hostname4.",
     }
-    ip_hostnames = {}
 
-    result = process_ptrs(ptrs, ip_hostnames)
+    result = process_ptrs(ptrs, {})
 
     assert result == {
         "1.1.1.1": {"hostname1"},
@@ -130,19 +102,10 @@ def test_process_ptrs():
         "20::4": {"hostname4"},
     }
 
-    # Test handling of dns.zone.UnknownOrigin exception
-    with patch("dns.zone.from_file", side_effect=dns.zone.UnknownOrigin):
-        result = get_records(zone_file_path1)
-        assert result == [{}, {}, {}, {}]
-
-    # Test handling of generic exceptions
-    with patch("dns.zone.from_file", side_effect=Exception("Generic error")):
-        result = get_records(zone_file_path1)
-        assert result == [{}, {}, {}, {}]
-
 
 def test_check_if_hostname():
     """Test checking if hostname is valid"""
+
     assert check_if_hostname("host-name.com") is True
     assert check_if_hostname("host-name") is True
     assert check_if_hostname("invalid@hostname.com") is False
@@ -153,24 +116,16 @@ def test_check_if_hostname():
 
 def test_create_fqdn():
     """Test creating FQDN from record"""
+
     assert create_fqdn("record", "example.com") == "record.example.com"
     assert create_fqdn("record.example.com.", "example.com") == "record.example.com"
 
 
-def test_check_git_key_path():
-    """Test checking git key path"""
-    with patch("os.path.exists", return_value=True):
-        assert check_git_key_path("dummy_path") is True
+def test_get_records_from_file():
+    """Test getting records from zone files, with and without $ORIGIN directive"""
 
-    with patch("os.path.exists", return_value=False):
-        assert check_git_key_path("dummy_path") is False
-
-
-def test_get_records():
-    """Test getting records from zone file"""
-
-    result1 = get_records(zone_file_path1)
-    result2 = get_records(zone_file_path2)
+    result1 = get_records_from_file(zone_file_path1)
+    result2 = get_records_from_file(zone_file_path2)
 
     expected_result1 = [
         {"alias.example.com": "www.example.com"},
@@ -203,3 +158,124 @@ def test_get_records():
 
     assert result1 == expected_result1
     assert result2 == expected_result2
+
+
+def test_get_records_from_file_invalid_files(tmpworkdir):  # pylint: disable=unused-argument
+    """get_records_from_file returns empty records for unparseable zone files"""
+
+    # no $ORIGIN directive and the fallback parse from filename-derived origin fails (no SOA)
+    Path("noorigin.zone").write_text("www 300 IN A 192.0.2.1\n", encoding="utf-8")
+    assert get_records_from_file("noorigin.zone") == [{}, {}, {}, {}]
+
+    # $ORIGIN present but content malformed
+    Path("garbage.zone").write_text("$ORIGIN garbage.example.com.\ngarbage garbage garbage\n", encoding="utf-8")
+    assert get_records_from_file("garbage.zone") == [{}, {}, {}, {}]
+
+
+def test_get_records_from_zone():
+    """get_records_from_zone parses a dns.zone.Zone object as produced by AXFR"""
+
+    zone = dns.zone.from_text(AXFR_ZONE_TEXT, origin="axfr.example.com.", relativize=False, check_origin=False)
+
+    cnames, a_aaaa, ptrs, ip_hostnames = get_records_from_zone(zone)
+
+    assert cnames == {"alias.axfr.example.com": "www.axfr.example.com"}
+    assert a_aaaa == {"www.axfr.example.com": {"192.0.2.31"}}
+    assert ptrs == {}
+    assert ip_hostnames == {"192.0.2.31": {"www.axfr.example.com"}}
+
+
+def test_build_ip_hostnames():
+    """build_ip_hostnames merges records from zone files (git/https) and AXFR zones into one mapping"""
+
+    axfr_zone = dns.zone.from_text(
+        "www.example.com. 300 IN A 192.168.1.3\naxfr.example.com. 300 IN A 192.0.2.30\n",
+        origin="example.com.",
+        relativize=False,
+        check_origin=False,
+    )
+
+    result = build_ip_hostnames([zone_file_path1, zone_file_path2], [axfr_zone])
+
+    # forward records from example.com.zone (file source)
+    assert "www.example.com" in result["192.168.1.3"]
+    # PTR records from 1.168.192.in-addr.arpa.zone (file source)
+    assert "ns1.example.com" in result["192.168.1.1"]
+    # A record from the AXFR zone
+    assert result["192.0.2.30"] == ["axfr.example.com"]
+    # hostname sets for the same IP are unioned across sources, not overwritten
+    assert set(result["192.168.1.3"]) == {"www.example.com", "alias.example.com"}
+
+
+def test_collect_dns_sources(httpserver):
+    """collect_dns_sources flattens group sources and splits them into AXFR and HTTPS buckets"""
+
+    axfr_source = {"type": "AXFR", "dns_server": "ns.example.org"}
+    http_source = {"type": "HTTPS", "http_url": "https://zones.example.com/archive.zip"}
+    other_source = {"type": "OTHER"}
+
+    httpserver.expect_request("/api/v1/groups").respond_with_json(
+        [{"id": 1, "name": "group1", "allowed_networks": []}, {"id": 2, "name": "group2", "allowed_networks": []}]
+    )
+    httpserver.expect_request("/api/v1/group/1/dns_sources").respond_with_json([axfr_source])
+    httpserver.expect_request("/api/v1/group/2/dns_sources").respond_with_json([http_source, other_source])
+
+    agreegate = AgreegateManager(httpserver.url_for(""), "dummy")
+    groups = agreegate.get_all_groups(only_with_dns_source=True)
+
+    dns_sources, axfr_sources, http_sources = collect_dns_sources(agreegate, groups)
+
+    assert dns_sources == [axfr_source, http_source, other_source]
+    assert axfr_sources == [axfr_source]
+    assert http_sources == [http_source]
+
+
+def test_write_output(tmpworkdir):  # pylint: disable=unused-argument
+    """write_output writes output json and removes the dns-zones scratch directory"""
+
+    dns_zones_dir = Path("dns-zones")
+    dns_zones_dir.mkdir()
+    (dns_zones_dir / "old_file.txt").write_text("old content", encoding="utf-8")
+
+    write_output({"1.2.3.4": ["example.com"]})
+
+    assert not dns_zones_dir.exists()
+    assert json.loads(Path("output.json").read_text(encoding="utf-8")) == {"1.2.3.4": ["example.com"]}
+
+
+def test_write_output_no_dns_zones_dir(tmpworkdir):  # pylint: disable=unused-argument
+    """write_output works when the dns-zones directory does not exist"""
+
+    write_output({"5.6.7.8": ["test.example.com"]})
+
+    assert json.loads(Path("output.json").read_text(encoding="utf-8")) == {"5.6.7.8": ["test.example.com"]}
+
+
+def test_run(gitolite_server, httpserver, axfr_server, monkeypatch):
+    """core.run end-to-end; combines zones from git, https and axfr sources served by local servers"""
+
+    zip_buf = io.BytesIO()
+    with zipfile.ZipFile(zip_buf, "w") as zipf:
+        zipf.writestr("https.example.com.zone", HTTPS_ZONE_TEXT)
+
+    httpserver.expect_request("/api/v1/groups").respond_with_json([{"id": 1, "name": "group1", "allowed_networks": []}])
+    httpserver.expect_request("/api/v1/group/1/dns_sources").respond_with_json(
+        [
+            {"type": "HTTPS", "http_url": httpserver.url_for("/archive.zip")},
+            {"type": "AXFR", "dns_server": "127.0.0.1", "port": axfr_server.port, "list_of_zones": ["axfr.example.com"]},
+        ]
+    )
+    httpserver.expect_request("/archive.zip").respond_with_data(zip_buf.getvalue(), content_type="application/zip")
+    axfr_server.add_zone(AXFR_ZONE_TEXT, "axfr.example.com.")
+    monkeypatch.setenv("SNER_AGREEGATE_URL", httpserver.url_for(""))
+    monkeypatch.setenv("SNER_AGREEGATE_APIKEY", "dummy")
+
+    result = run({"config": gitolite_server})
+
+    assert result == 0
+    output = json.loads(Path("output.json").read_text(encoding="utf-8"))
+    assert output["192.0.2.11"] == ["www.git1.example.com"]
+    assert output["192.0.2.12"] == ["www.git2.example.com"]
+    assert output["192.0.2.21"] == ["www.https.example.com"]
+    assert sorted(output["192.0.2.31"]) == ["alias.axfr.example.com", "www.axfr.example.com"]
+    assert not Path("dns-zones").exists()

--- a/server/tests/plugin/auror_hostnames/test_decompress.py
+++ b/server/tests/plugin/auror_hostnames/test_decompress.py
@@ -1,0 +1,53 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin decompress tests
+"""
+
+import io
+import zipfile
+from pathlib import Path
+
+from sner.plugin.auror_hostnames.decompress import extract_zone_files
+
+
+def test_extract_zone_files(tmpworkdir):  # pylint: disable=unused-argument
+    """extract_zone_files extracts .zone files from a zip archive"""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zipf:
+        zipf.writestr("example.com.zone", "dummy zone data")
+        zipf.writestr("readme.txt", "not a zone")
+        zipf.writestr("nested/beta.example.com.zone", "dummy zone data")
+
+    zone_file_paths = extract_zone_files(buf.getvalue())
+
+    assert zone_file_paths == ["dns-zones/example.com.zone", "dns-zones/nested/beta.example.com.zone"]
+    for path in zone_file_paths:
+        assert Path(path).read_text(encoding="utf-8") == "dummy zone data"
+    assert not Path("dns-zones/readme.txt").exists()
+
+
+def test_extract_zone_files_empty_input():
+    """extract_zone_files returns empty list for empty input"""
+
+    assert extract_zone_files(None) == []
+    assert extract_zone_files(b"") == []
+
+
+def test_extract_zone_files_not_an_archive():
+    """extract_zone_files returns empty list when data is not a zip archive"""
+
+    assert extract_zone_files(b"not a zip archive") == []
+
+
+def test_extract_zone_files_corrupted_archive(tmpworkdir):  # pylint: disable=unused-argument
+    """extract_zone_files returns empty list when the archive is corrupted"""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zipf:
+        zipf.writestr("example.com.zone", "dummy zone data" * 100)
+    # valid magic and central directory, corrupted member data
+    corrupted = bytearray(buf.getvalue())
+    corrupted[30:40] = b"\x00" * 10
+
+    assert extract_zone_files(bytes(corrupted)) == []

--- a/server/tests/plugin/auror_hostnames/test_git.py
+++ b/server/tests/plugin/auror_hostnames/test_git.py
@@ -1,0 +1,30 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin git tests
+"""
+
+from pathlib import Path
+
+from sner.plugin.auror_hostnames.git import run
+
+
+def test_run(gitolite_server):
+    """run lists gitolite repositories, clones them and returns discovered zone file paths"""
+
+    zone_file_paths = run({"config": gitolite_server})
+
+    assert zone_file_paths == ["dns-zones/zones/repo1/git1.example.com.zone", "dns-zones/zones/repo2/git2.example.com.zone"]
+    for path in zone_file_paths:
+        assert "SOA" in Path(path).read_text(encoding="utf-8")
+
+
+def test_run_missing_key(tmpworkdir):  # pylint: disable=unused-argument
+    """run returns empty list when the configured git key does not exist"""
+
+    assert run({"config": {"git_key_path": "/nonexistent/gitkey", "git_server": "git.example.com"}}) == []
+
+
+def test_run_git_error(gitolite_server):
+    """run returns empty list when git operations fail"""
+
+    assert run({"config": {"git_key_path": gitolite_server["git_key_path"], "git_server": "fail.example.com"}}) == []

--- a/server/tests/plugin/auror_hostnames/test_http.py
+++ b/server/tests/plugin/auror_hostnames/test_http.py
@@ -1,0 +1,79 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin http tests
+"""
+
+import io
+import zipfile
+from pathlib import Path
+
+from werkzeug.wrappers import Response
+
+from sner.plugin.auror_hostnames.http import run
+
+
+def zone_archive():
+    """build zone archive bytes"""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zipf:
+        zipf.writestr("zones/example.com.zone", "dummy zone data")
+        zipf.writestr("readme.txt", "not a zone")
+    return buf.getvalue()
+
+
+def test_run(tmpworkdir, httpserver):  # pylint: disable=unused-argument
+    """run downloads the archive and extracts zone files"""
+
+    httpserver.expect_request("/archive.zip").respond_with_data(zone_archive(), content_type="application/zip")
+
+    zone_file_paths = run({"http_url": httpserver.url_for("/archive.zip")})
+
+    assert zone_file_paths == ["dns-zones/zones/example.com.zone"]
+    assert Path("dns-zones/zones/example.com.zone").read_text(encoding="utf-8") == "dummy zone data"
+
+
+def test_run_with_auth(tmpworkdir, httpserver):  # pylint: disable=unused-argument
+    """run sends basic auth when credentials are configured"""
+
+    httpserver.expect_request(
+        "/archive.zip", headers={"Authorization": "Basic YWxpY2U6c2VjcmV0"}
+    ).respond_with_data(zone_archive(), content_type="application/zip")
+
+    zone_file_paths = run(
+        {
+            "http_url": httpserver.url_for("/archive.zip"),
+            "http_auth_login": "alice",
+            "http_auth_password": "secret",
+        }
+    )
+
+    assert zone_file_paths == ["dns-zones/zones/example.com.zone"]
+
+
+def test_run_empty_credentials_send_no_auth(tmpworkdir, httpserver):  # pylint: disable=unused-argument
+    """run treats empty-string credentials as absent and sends no authorization header"""
+
+    def handler(request):
+        assert "Authorization" not in request.headers
+        return Response(zone_archive(), content_type="application/zip")
+
+    httpserver.expect_request("/archive.zip").respond_with_handler(handler)
+
+    zone_file_paths = run(
+        {
+            "http_url": httpserver.url_for("/archive.zip"),
+            "http_auth_login": "",
+            "http_auth_password": "",
+        }
+    )
+
+    assert zone_file_paths == ["dns-zones/zones/example.com.zone"]
+
+
+def test_run_download_failed(tmpworkdir, httpserver):  # pylint: disable=unused-argument
+    """run returns empty list when the archive cannot be downloaded"""
+
+    httpserver.expect_request("/missing.zip").respond_with_data("not found", status=404)
+
+    assert run({"http_url": httpserver.url_for("/missing.zip")}) == []

--- a/server/tests/plugin/auror_hostnames/test_manager.py
+++ b/server/tests/plugin/auror_hostnames/test_manager.py
@@ -1,0 +1,116 @@
+# This file is part of sner4 project governed by MIT license, see the LICENSE.txt file.
+"""
+auror_hostnames plugin agreegate manager tests
+"""
+
+import pytest
+
+from sner.plugin.auror_hostnames.manager import AgreegateApiError, AgreegateManager
+
+APIKEY = "dummy-apikey"
+
+
+def test_apicall(httpserver):
+    """apicall sends the api key header and returns decoded json body"""
+
+    httpserver.expect_request("/dummy", headers={"X-API-KEY": APIKEY}).respond_with_json({"result": "ok"})
+
+    assert AgreegateManager(httpserver.url_for(""), APIKEY).apicall("GET", "/dummy") == {"result": "ok"}
+
+
+def test_apicall_failure(httpserver):
+    """apicall raises AgreegateApiError on non-OK status"""
+
+    httpserver.expect_request("/fail").respond_with_data("error message text", status=500)
+
+    with pytest.raises(AgreegateApiError, match="agreegate apicall failed"):
+        AgreegateManager(httpserver.url_for(""), APIKEY).apicall("POST", "/fail")
+
+
+def test_from_env(monkeypatch):
+    """from_env initializes manager from environment variables"""
+
+    monkeypatch.setenv("SNER_AGREEGATE_URL", "https://agreegate.example/")
+    monkeypatch.setenv("SNER_AGREEGATE_APIKEY", APIKEY)
+
+    manager = AgreegateManager.from_env()
+
+    assert manager.url == "https://agreegate.example"
+    assert manager.apikey == APIKEY
+
+
+def test_from_env_missing_url(monkeypatch):
+    """from_env fails when URL env var is not set"""
+
+    monkeypatch.delenv("SNER_AGREEGATE_URL", raising=False)
+
+    with pytest.raises(AgreegateApiError, match="missing SNER_AGREEGATE_URL"):
+        AgreegateManager.from_env()
+
+
+def test_from_env_missing_apikey(monkeypatch):
+    """from_env fails when API key env var is not set"""
+
+    monkeypatch.setenv("SNER_AGREEGATE_URL", "https://agreegate.example")
+    monkeypatch.delenv("SNER_AGREEGATE_APIKEY", raising=False)
+
+    with pytest.raises(AgreegateApiError, match="missing SNER_AGREEGATE_APIKEY"):
+        AgreegateManager.from_env()
+
+
+def test_get_all_groups(httpserver):
+    """get_all_groups returns validated Group objects"""
+
+    groups_payload = [{"id": 1, "name": "group1", "description": "desc", "allowed_networks": ["127.0.0.0/8"]}]
+    httpserver.expect_request("/api/v1/groups", headers={"X-API-KEY": APIKEY}).respond_with_json(groups_payload)
+
+    result = AgreegateManager(httpserver.url_for(""), APIKEY).get_all_groups(only_with_dns_source=True)
+
+    assert len(result) == 1
+    assert result[0].name == "group1"
+
+
+def test_get_all_groups_validation_error(httpserver):
+    """get_all_groups raises AgreegateApiError on invalid payload"""
+
+    httpserver.expect_request("/api/v1/groups").respond_with_json([{"invalid": "shape"}])
+
+    with pytest.raises(AgreegateApiError, match="groups response validation failed"):
+        AgreegateManager(httpserver.url_for(""), APIKEY).get_all_groups()
+
+
+def test_get_group_dns_sources(httpserver):
+    """get_group_dns_sources returns validated list of source dictionaries"""
+
+    dns_sources_payload = [{"type": "AXFR", "dns_server": "ns.example.org"}]
+    httpserver.expect_request("/api/v1/group/1/dns_sources").respond_with_json(dns_sources_payload)
+
+    assert AgreegateManager(httpserver.url_for(""), APIKEY).get_group_dns_sources(1) == dns_sources_payload
+
+
+def test_get_group_dns_sources_unwraps_dict_payload(httpserver):
+    """get_group_dns_sources unwraps the dns_sources key from a dict response"""
+
+    payload = {"dns_sources": [{"type": "HTTPS", "http_url": "https://zones.example.com/archive.zip"}]}
+    httpserver.expect_request("/api/v1/group/1/dns_sources").respond_with_json(payload)
+
+    assert AgreegateManager(httpserver.url_for(""), APIKEY).get_group_dns_sources(1) == payload["dns_sources"]
+
+
+def test_get_group_dns_sources_requires_group_id():
+    """get_group_dns_sources validates required group_id"""
+
+    with pytest.raises(ValueError, match="group_id is required"):
+        AgreegateManager("https://agreegate.example", APIKEY).get_group_dns_sources(None)
+
+    with pytest.raises(ValueError, match="group_id is required"):
+        AgreegateManager("https://agreegate.example", APIKEY).get_group_dns_sources("   ")
+
+
+def test_get_group_dns_sources_validation_error(httpserver):
+    """get_group_dns_sources raises AgreegateApiError on invalid payload"""
+
+    httpserver.expect_request("/api/v1/group/1/dns_sources").respond_with_json({"invalid": "shape"})
+
+    with pytest.raises(AgreegateApiError, match="group dns_sources response validation failed"):
+        AgreegateManager(httpserver.url_for(""), APIKEY).get_group_dns_sources(1)


### PR DESCRIPTION
- Added support for collecting hostnames from three independent sources: AXFR (DNS zone transfer via Agreegate), HTTPS (zone archive download via Agreegate), and Git (zone file repository clone)
- All three sources run in a single job and their results are merged — overlapping IPs accumulate hostnames from all sources
- Integrated with Agreegate API to discover configured DNS sources per group; support both numeric group IDs and dns_sources response envelope
- Supports AES-encrypted ZIP archives using pyzipper; detect archive format via filetype library with tarfile fallback; extract only *.zone files from all archive types (zip, tar, 7z, rar)
- Added specific NOTAUTH log message for AXFR refusals to make TSIG/ACL misconfigurations easy to diagnose
- Added filetype, py7zr, pyzipper, rarfile to requirements.txt
- Added  test coverage for AXFR, HTTP, Git, decompress pipelines and hostname union behavior